### PR TITLE
Static vega-lite graph on /loader page

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -1,0 +1,60 @@
+"""NapariBridge class.
+
+Communicates between the Flask-SocketIO app and the NapariClient.
+"""
+import logging
+from queue import Empty, Queue
+from threading import get_ident
+
+from flask_socketio import SocketIO
+
+from napari_client import NapariClient
+
+LOGGER = logging.getLogger("webmon")
+
+
+class NapariBridge:
+
+    # Number of seconds between sending/receiving data.
+    POLL_INTERVAL_MS = 100
+
+    def __init__(self, socketio: SocketIO, client: NapariClient):
+        self.socketio = socketio
+        self.client = client
+        self.commands = Queue()
+
+    def send_command(self, command) -> None:
+        """Put into queue for background_task to send."""
+        self.commands.put(command)
+
+    def background_task(self) -> None:
+        """Send data to/from the viewer and napari."""
+        poll_seconds = self.POLL_INTERVAL_MS / 1000
+        tid = get_ident()
+        LOGGER.info("Webmon: Background task thread_id=%d", tid)
+
+        while True:
+            LOGGER.info("Sleeping %f", poll_seconds)
+            self.socketio.sleep(poll_seconds)
+
+            if self.client is None:
+                continue
+
+            self._send_commands()  # Send any pending commands.
+
+            # We just send the whole thing every time. We could potentially
+            # only send if the data had changed since the last time
+            # we sent it. To cut down the spamming viewer with repeated
+            # data.
+            tile_data = self.client.napari_data['tile_data']
+            self.socketio.emit('set_tile_data', tile_data, namespace='/test')
+
+    def _send_commands(self) -> None:
+        """Send all pending commands."""
+        while True:
+            try:
+                command = self.commands.get_nowait()
+            except Empty:
+                break  # No more commands to end.
+            LOGGER.info("Send command to napari: %s", command)
+            self.client.send_command(command)

--- a/bridge.py
+++ b/bridge.py
@@ -34,7 +34,7 @@ class NapariBridge:
         LOGGER.info("Webmon: Background task thread_id=%d", tid)
 
         while True:
-            LOGGER.info("Sleeping %f", poll_seconds)
+            # LOGGER.info("Sleeping %f", poll_seconds)
             self.socketio.sleep(poll_seconds)
 
             if self.client is None:

--- a/handler.py
+++ b/handler.py
@@ -1,0 +1,51 @@
+"""WebmonHandlers class.
+
+SocketIO handlers for webmon.
+"""
+import logging
+import os
+from threading import Lock
+
+from flask import session
+from flask_socketio import Namespace, emit
+
+from bridge import NapariBridge
+
+LOGGER = logging.getLogger("webmon")
+
+
+class WebmonHandlers(Namespace):
+    """Generic handlers right now, but will be per-page soon?"""
+
+    def __init__(self, bridge: NapariBridge, namespace: str):
+        super().__init__(namespace)
+        self.bridge = bridge
+        self.lock = Lock()
+        self.thread = None
+
+    def on_connection_test(self, message):
+        LOGGER.info("connection_test: %s", message)
+        session['receive_count'] = session.get('receive_count', 0) + 1
+        emit(
+            'connection_response',
+            {'data': message['data'], 'count': session['receive_count']},
+        )
+
+    def on_input_data_request(self, message):
+        session['receive_count'] = session.get('receive_count', 0) + 1
+        data = {'client': "webmon", 'pid': os.getpid()}
+        emit('input_data_response', json.dumps(data))
+
+    def on_gui_input(self, message):
+        self.bridge.send_command(message)
+
+    def on_connect(self):
+        LOGGER.info("on_connect")
+        global thread
+
+        # Lock is so that we only create one background task that
+        # is shared among for all viewers.
+        with self.lock:
+            if self.thread is None:
+                LOGGER.info("Webmon: Creating background task...")
+                self.thread = self.bridge.start_background_task()

--- a/handlers.py
+++ b/handlers.py
@@ -2,6 +2,7 @@
 
 SocketIO handlers for webmon.
 """
+import json
 import logging
 import os
 from threading import Lock

--- a/js/build.js
+++ b/js/build.js
@@ -1,6 +1,7 @@
 require('esbuild').build({
 	entryPoints: [
 		'src/viewer.js',
+		'src/loader.js'
 		// other files you want to end up in /static
 	],
 	format: 'esm',

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2,10 +2,38 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/clone": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.0.tgz",
+      "integrity": "sha512-d/aS/lPOnUSruPhgNtT8jW39fHRVTLQy9sodysP1kkG8EdAtdZu1vt8NJaYA8w/6Z9j8izkAsx1A/yJhcYR1CA=="
+    },
+    "@types/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ=="
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -32,6 +60,39 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -47,6 +108,134 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
+    "d3-array": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+      "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "requires": {
+        "delaunator": "4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      }
+    },
+    "d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-geo": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
+      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+      "requires": {
+        "d3-array": ">=2.5"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
+      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "requires": {
+        "commander": "2",
+        "d3-array": "1 - 2",
+        "d3-geo": "1.12.0 - 2",
+        "resolve": "^1.1.10"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+    },
+    "d3-scale": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "1 - 2",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-shape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.0.0.tgz",
+      "integrity": "sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
+      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+    },
     "dat.gui": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.7.tgz",
@@ -59,6 +248,16 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "engine.io-client": {
       "version": "3.4.4",
@@ -96,6 +295,44 @@
       "integrity": "sha512-HMvPNxDIhEGO/YUh8oO8oxQ1g+ttWz2anUF7NJmQglj2XfJS8zd8mP0Sb2y+jE1SVk3UjD/rYhdsEOFULN9/xw==",
       "dev": true
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -109,20 +346,51 @@
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "isarray": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
       "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
     },
+    "json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "parseqs": {
       "version": "0.0.6",
@@ -133,6 +401,40 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
       "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "socket.io-client": {
       "version": "2.3.1",
@@ -162,6 +464,24 @@
         "isarray": "2.0.1"
       }
     },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
     "three": {
       "version": "0.123.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.123.0.tgz",
@@ -171,6 +491,416 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+    },
+    "vega": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.17.0.tgz",
+      "integrity": "sha512-2Rm9aS3cSMXE55YgjfkuOmvSBMtiM/85/qX/WHLc+YiJacKGiwY9yzeC+w2Ft50JUs3nKZc1KB90ePgf5mfo0Q==",
+      "requires": {
+        "vega-crossfilter": "~4.0.5",
+        "vega-dataflow": "~5.7.3",
+        "vega-encode": "~4.8.3",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~3.0.0",
+        "vega-force": "~4.0.7",
+        "vega-format": "~1.0.4",
+        "vega-functions": "~5.8.0",
+        "vega-geo": "~4.3.7",
+        "vega-hierarchy": "~4.0.9",
+        "vega-label": "~1.0.0",
+        "vega-loader": "~4.4.0",
+        "vega-parser": "~6.1.0",
+        "vega-projection": "~1.4.5",
+        "vega-regression": "~1.0.9",
+        "vega-runtime": "~6.1.3",
+        "vega-scale": "~7.1.1",
+        "vega-scenegraph": "~4.9.2",
+        "vega-statistics": "~1.7.9",
+        "vega-time": "~2.0.4",
+        "vega-transforms": "~4.9.3",
+        "vega-typings": "~0.19.0",
+        "vega-util": "~1.16.0",
+        "vega-view": "~5.9.0",
+        "vega-view-transforms": "~4.5.8",
+        "vega-voronoi": "~4.1.5",
+        "vega-wordcloud": "~4.1.3"
+      }
+    },
+    "vega-canvas": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
+      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+    },
+    "vega-crossfilter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
+      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-dataflow": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.3.tgz",
+      "integrity": "sha512-2ipzKgQUmbSXcQBH+9XF0BYbXyZrHvjlbJ8ifyRWYQk78w8kMvE6wy/rcdXYK6iVZ6aAbEDDT7jTI+rFt3tGLA==",
+      "requires": {
+        "vega-format": "^1.0.4",
+        "vega-loader": "^4.3.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-embed": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.13.0.tgz",
+      "integrity": "sha512-uPOQy7vAHeMKBWWT3ZwcZ9t/2IpWhQYxqheQBHY2HthLYY/hLZpn5Fo6or/lttCnxYk49mJHsi3R8o1AX5TYXA==",
+      "requires": {
+        "fast-json-patch": "^3.0.0-1",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "semver": "^7.3.2",
+        "vega-schema-url-parser": "^2.1.0",
+        "vega-themes": "^2.9.1",
+        "vega-tooltip": "^0.24.2"
+      }
+    },
+    "vega-encode": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
+      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-event-selector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
+    },
+    "vega-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-3.0.0.tgz",
+      "integrity": "sha512-/ObjIOK94MB+ziTuh8HZt2eWlKUPT/piRJLal5tx5QL1sQbfRi++7lHKTaKMLXLqc4Xqp9/DewE3PqQ6tYzaUA==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-force": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
+      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "requires": {
+        "d3-force": "^2.1.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
+      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-format": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "vega-time": "^2.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-functions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.8.0.tgz",
+      "integrity": "sha512-xaUqWZHEX+EuJuKfN0Biux3rrCHDEHmMbW7LHYyyEqguR0i6+zhtOSUEWmYqDfzB/+BlIwCk5Vif6q6/mzJxbQ==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-expression": "^3.0.0",
+        "vega-scale": "^7.1.1",
+        "vega-scenegraph": "^4.9.2",
+        "vega-selections": "^5.1.4",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-geo": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.7.tgz",
+      "integrity": "sha512-5HC1D9Z/WYuM1Gmlk8PxuRKgeN8snNWsfKO4E9PTmR7wo7tuU/2SGlRoE27aTsgwMMpBIrpRbSgKtgh5l/fMUQ==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-projection": "^1.4.5",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-hierarchy": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
+      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "requires": {
+        "d3-hierarchy": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-label": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.0.0.tgz",
+      "integrity": "sha512-hCdm2pcHgkKgxnzW9GvX5JmYNiUMlOXOibtMmBzvFBQHX3NiV9giQ5nsPiQiFbV08VxEPtM+VYXr2HyrIcq5zQ==",
+      "requires": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-lite": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.17.0.tgz",
+      "integrity": "sha512-MO2XsaVZqx6iWWmVA5vwYFamvhRUsKfVp7n0pNlkZ2/21cuxelSl92EePZ2YGmzL6z4/3K7r/45zaG8p+qNHeg==",
+      "requires": {
+        "@types/clone": "~2.1.0",
+        "@types/fast-json-stable-stringify": "^2.0.0",
+        "array-flat-polyfill": "^1.0.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.3",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~2.0.0",
+        "tslib": "~2.0.3",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~3.0.0",
+        "vega-util": "~1.16.0",
+        "yargs": "~16.0.3"
+      }
+    },
+    "vega-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.0.tgz",
+      "integrity": "sha512-e5enQECdau7rJob0NFB5pGumh3RaaSWWm90+boxMy3ay2b4Ki/3XIvo+C4F1Lx04qSxvQF7tO2LJcklRm6nqRA==",
+      "requires": {
+        "d3-dsv": "^2.0.0",
+        "node-fetch": "^2.6.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "vega-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.0.tgz",
+      "integrity": "sha512-u14bHXV8vtcuMIJkMNoDAJ4Xu3lwKIkep+YEkPumWvlwl3fClWy26EAcwTneeM3rXu2F6ZJI6W3ddu/If8u13w==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-event-selector": "^2.0.6",
+        "vega-functions": "^5.8.0",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-projection": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
+      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "requires": {
+        "d3-geo": "^2.0.1",
+        "d3-geo-projection": "^3.0.0"
+      }
+    },
+    "vega-regression": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
+      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-runtime": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
+      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-scale": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
+      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.2",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-scenegraph": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.2.tgz",
+      "integrity": "sha512-epm1CxcB8AucXQlSDeFnmzy0FCj+HV2k9R6ch2lfLRln5lPLEfgJWgFcFhVf5jyheY0FSeHH52Q5zQn1vYI1Ow==",
+      "requires": {
+        "d3-path": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "vega-canvas": "^1.2.5",
+        "vega-loader": "^4.3.3",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-schema-url-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.1.0.tgz",
+      "integrity": "sha512-JHT1PfOyVzOohj89uNunLPirs05Nf59isPT5gnwIkJph96rRgTIBJE7l7yLqndd7fLjr3P8JXHGAryRp74sCaQ=="
+    },
+    "vega-selections": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.1.4.tgz",
+      "integrity": "sha512-L7CHwcIjVf90GoW2tS2x5O496O5Joaerp5A1KM6VJ1uo4z6KfqxY6M/328a/uaAs0LC5qbQgXT3htFbtUrPW/A==",
+      "requires": {
+        "vega-expression": "^3.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-statistics": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.9.tgz",
+      "integrity": "sha512-T0sd2Z08k/mHxr1Vb4ajLWytPluLFYnsYqyk4SIS5czzUs4errpP2gUu63QJ0B7CKNu33vnS9WdOMOo/Eprr/Q==",
+      "requires": {
+        "d3-array": "^2.7.1"
+      }
+    },
+    "vega-themes": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.9.1.tgz",
+      "integrity": "sha512-N6GU8u1EpfqxswXpBKLYouD3gYGfvrKWTC07JSrnlvGUzKzXMPDm4fN8FP8+cBpTwBL6JDZBd86A1Haea/nTfQ=="
+    },
+    "vega-time": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
+      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-time": "^2.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-tooltip": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.24.2.tgz",
+      "integrity": "sha512-b7IeYQl/piNVsMmTliOgTnwSOhBs67KqoZ9UzP1I3XpH7TKbSuc3YHA7b1CSxkRR0hHKdradby4UI8c9rdH74w==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-transforms": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.3.tgz",
+      "integrity": "sha512-PdqQd5oPlRyD405M2w+Sz9Bo+i7Rwi8o03SVK7RaeQsJC2FffKGJ6acIaSEgOq+yD1Q2k/1SePmCXcmLUlIiEA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-typings": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.19.1.tgz",
+      "integrity": "sha512-OSyNYwMJ8FayTTNU/gohprbt1EFQBpoiMPP9p2vqo1O9z45XVnotQ92jYHAhraI6gWiMIIfo4OjPbSe/GX7etg==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-util": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.0.tgz",
+      "integrity": "sha512-6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog=="
+    },
+    "vega-view": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.9.0.tgz",
+      "integrity": "sha512-HqRFuqO2OwoPHHK+CVt8vB8fu2L8GjQerLpmEpglWtCPDns5+gn5B6F7M8Ah8v24WlfqW7cLrY81t9OloPZOyw==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-timer": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-format": "^1.0.4",
+        "vega-functions": "^5.8.0",
+        "vega-runtime": "^6.1.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
+      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-voronoi": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
+      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "requires": {
+        "d3-delaunay": "^5.3.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-wordcloud": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
+      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "requires": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.1.1",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "ws": {
       "version": "6.1.4",
@@ -184,6 +914,30 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
+    "yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+      "requires": {
+        "cliui": "^7.0.0",
+        "escalade": "^3.0.2",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.1",
+        "yargs-parser": "^20.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
     },
     "yeast": {
       "version": "0.1.2",

--- a/js/package.json
+++ b/js/package.json
@@ -8,6 +8,9 @@
   "dependencies": {
     "dat.gui": "^0.7.7",
     "socket.io-client": "~2.3.0",
-    "three": "^0.123.0"
+    "three": "^0.123.0",
+    "vega": "5.17.0",
+    "vega-lite": "^4.17.0",
+    "vega-embed": "^6.13.0"
   }
 }

--- a/js/src/loader.js
+++ b/js/src/loader.js
@@ -1,10 +1,38 @@
 //
 // loader.js
 //
+// Graphs about the ChunkLoader.
+//
 import vegaEmbed from 'vega-embed';
 
+export function connectSocketInput() {
+    console.log("connectSocketInput")
+
+    document.addEventListener("DOMContentLoaded", function (event) {
+
+        // Connect invoked when a connection with the server setup.
+        internalParams.socket.on('connect', function () {
+            console.log("connect")
+            internalParams.socket.emit('connection_test', { data: 'loader.js' });
+            internalParams.socket.emit('input_data_request', { data: 'requesting data' });
+        });
+
+        internalParams.socket.on('connection_response', function (msg) {
+            console.log("connection_response:", msg);
+        });
+
+        internalParams.socket.on('input_data_response', function (msg) {
+            console.log("input_data_response", msg);
+        });
+
+        internalParams.socket.on('set_tile_data', function (msg) {
+            setTileData(msg);
+        });
+    });
+}
+
 function showChart() {
-    var yourVlSpec = {
+    var spec = {
         $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
         description: 'A simple bar chart with embedded data.',
         data: {
@@ -26,10 +54,14 @@ function showChart() {
             y: { field: 'b', type: 'quantitative' }
         }
     };
-    vegaEmbed('#vis', yourVlSpec);
+    vegaEmbed('#vis', spec, { defaultStyle: true })
+        .then(function (result) {
+            const view = result.view;
+        }
 }
 
 export function startLoader() {
     console.log("startLoader");
     showChart();
+    connectSocketInput();
 }

--- a/js/src/loader.js
+++ b/js/src/loader.js
@@ -1,0 +1,35 @@
+//
+// loader.js
+//
+import vegaEmbed from 'vega-embed';
+
+function showChart() {
+    var yourVlSpec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+        description: 'A simple bar chart with embedded data.',
+        data: {
+            values: [
+                { a: 'A', b: 28 },
+                { a: 'B', b: 55 },
+                { a: 'C', b: 43 },
+                { a: 'D', b: 91 },
+                { a: 'E', b: 81 },
+                { a: 'F', b: 53 },
+                { a: 'G', b: 19 },
+                { a: 'H', b: 87 },
+                { a: 'I', b: 52 }
+            ]
+        },
+        mark: 'bar',
+        encoding: {
+            x: { field: 'a', type: 'ordinal' },
+            y: { field: 'b', type: 'quantitative' }
+        }
+    };
+    vegaEmbed('#vis', yourVlSpec);
+}
+
+export function startLoader() {
+    console.log("startLoader");
+    showChart();
+}

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -1,9 +1,7 @@
+//
 // viewer.js
 //
-// Proof of Concept Napari Monitor WebUI. Right now focusing just on the 
-// display of the octree tiles and the view into those.
-//
-// Modified from https://github.com/ageller/FlaskTest
+// WebGL display of which octree tiles are visible in napari.
 //
 import * as THREE from 'three';
 import { GUI } from 'dat.gui';
@@ -71,16 +69,13 @@ function setTileData(msg) {
 // https://github.com/miguelgrinberg/Flask-SocketIO
 //
 export function connectSocketInput() {
-	console.log("connectSocketInput")
 
 	document.addEventListener("DOMContentLoaded", function (event) {
-
-		console.log("DOMContentLoaded")
 
 		// Connect invoked when a connection with the server setup.
 		internalParams.socket.on('connect', function () {
 			console.log("connect")
-			internalParams.socket.emit('connection_test', { data: 'I\'m the viewer!' });
+			internalParams.socket.emit('connection_test', { data: 'viewer.js' });
 			internalParams.socket.emit('input_data_request', { data: 'requesting data' });
 		});
 

--- a/lib/logging.py
+++ b/lib/logging.py
@@ -1,0 +1,59 @@
+"""Logging.
+
+Very strawman right now, just to get started.
+"""
+
+import logging
+from pathlib import Path
+
+LOGGER = logging.getLogger("webmon")
+
+# If true we delete the previous log file on startup. There are pros and
+# cons to deleting it depending on how you are monitoring it.
+DELETE_LOG_FILE = False
+
+FORMAT = "%(levelname)s - %(name)s - %(message)s"
+
+
+def _log_to_file(path: str) -> None:
+    """Log "webmon" messages to the given file.
+
+    Parameters
+    ----------
+    path : str
+        Log to this file path.
+    """
+    if DELETE_LOG_FILE:
+        try:
+            Path(path).unlink()
+        except FileNotFoundError:
+            pass  # It didn't exist.
+
+    fh = logging.FileHandler(path)
+
+    formatter = logging.Formatter(FORMAT)
+    fh.setFormatter(formatter)
+    LOGGER.addHandler(fh)
+
+    LOGGER.setLevel(logging.DEBUG)
+    LOGGER.info("Writing log to %s", path)
+
+
+def _log_to_console() -> None:
+    """Log to console."""
+    logging.basicConfig(level=logging.DEBUG, format=FORMAT)
+    LOGGER.info("Logging to console.")
+
+
+def setup_logging(log_path: str) -> None:
+    """Setup logging to file or console.
+
+    Parameters
+    ----------
+    log_path : str
+        The path the write the log file.
+    """
+    if log_path is not None:
+        _log_to_file(log_path)
+    else:
+        _log_to_console()

--- a/napari_client.py
+++ b/napari_client.py
@@ -185,12 +185,13 @@ class NapariClient(Thread):
 
         return True  # Keep polling
 
-    def post_command(self, command) -> None:
+    def send_command(self, command) -> None:
         """Send new command to napari.
         """
-        LOGGER.info("Posting command %s", command)
+        LOGGER.info("Sending command %s", command)
 
         try:
+            # Put on the shared command queue.
             self._shared.commands.put(command)
         except ConnectionRefusedError:
             self._log("NapariClient: ConnectionRefusedError")

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,9 +17,6 @@
 			<a href="/loader" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white mr-4">
 				Loader
 			</a>
-			<a href="/loader" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white mr-4">
-				Loader
-			</a>
 			<a href="/blank" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white mr-4">
 				Blank
 			</a>

--- a/templates/loader.html
+++ b/templates/loader.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="bg-red-50 border-t-4 border-red-900 rounded-b px-4 py-3 shadow-md my-2" role="alert">
-	<p class="font-bold">Coming Soon: Stuff about the ChunkLoader.</p>
-</div>
+<div id="vis"></div>
+<div id="WebGLContainer"></div>
+<script type="module">
+	import { startLoader } from '/static/loader.js';
+	startLoader();
+</script>
 {% endblock %}

--- a/webmon.py
+++ b/webmon.py
@@ -25,7 +25,7 @@ from flask import Flask, render_template
 from flask_socketio import SocketIO
 
 from bridge import NapariBridge
-from handler import WebmonHandlers
+from handlers import WebmonHandlers
 from lib.numpy_json import NumpyJSON
 from napari_client import NapariClient
 

--- a/webmon.py
+++ b/webmon.py
@@ -49,25 +49,26 @@ USE_RELOADER = False
 # cons to deleting it depending on how you are monitoring it.
 DELETE_LOG_FILE = False
 
-# The NapariClient
-client = None
-
+# Flask.
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
 
-# Specifiy eventlet just so we are all running the same thing. However
+# Eventlet
+# --------
+# Specify eventlet just so we are all running the same thing. However
 # eventlet developer says it's really intended for 100's of simultaneous
-# connections! So maybe it is overkill.
+# connections! So maybe it is overkill. But what else should we use?
 #
-# Note that we don't call eventlet.monkey_patch(). That causes a problem
-# with SharedMemoryManager's socket:
+# Note that we don't call eventlet.monkey_patch(). It patches various
+# standard library functions to be "green" compatible. But it causes
+# a crash today with SharedMemoryManager:
 #
 # https://github.com/eventlet/eventlet/issues/670
 #
-# But monkey_patch() doesn't seem to be necessary. It patches various
-# standard library functions to be "green" compatible.
+# And monkey_patch() doesn't seem to be necessary for us?
 ASYNC_MODE = "eventlet"
 
+# Flask-SocketIO.
 socketio = SocketIO(app, async_mode=ASYNC_MODE, json=NumpyJSON)
 
 thread = None
@@ -75,7 +76,7 @@ thread_lock = Lock()
 
 
 class WebmonHandlers(Namespace):
-    """Generic handlers right now, but will be per-page soon."""
+    """Generic handlers right now, but will be per-page soon?"""
 
     def __init__(self, namespace: str, bridge: NapariBridge):
         super().__init__(namespace)

--- a/webmon.py
+++ b/webmon.py
@@ -142,18 +142,19 @@ class WebmonHandlers(Namespace):
 
 @app.route("/viewer")
 def viewer():
-    # The tile viewer.
+    """The tile viewer page."""
     return render_template("viewer.html")
 
 
 @app.route("/loader")
 def loader():
-    # The chunk loader.
+    """The ChunkLoader page"""
     return render_template("loader.html")
 
 
 @app.route("/blank")
 def blank():
+    """Black page as ane example how to expand."""
     return render_template("blank.html")
 
 


### PR DESCRIPTION
# Description 

1. Lots of refactoring of `webmon.py` unrelated to vega-lite.
    * Extract new `bridge.py` file with new `NapariBridge` class.
    * Extract new `handlers.py` file with `WebmonHandlers` class to group handlers together.
    * Extract new `lib/logging.py` file.
    * Cleanup how we deal with `/stop` endpoint.
2. Add Vega-Lite dependencies.
3. Add totally static vega-lite example graph on new /loader page:

<img width="335" alt="Screen Shot 2020-11-30 at 8 56 37 AM" src="https://user-images.githubusercontent.com/4163446/100618647-1ae6c700-32ea-11eb-8d76-ad018c2ae648.png">

# Notes

* Run `python webmon.py` to start the HTTP server without any napari connection.
* Useful as quick check the HTTP side is working.
