### PR TITLE
Support really big levels with sparse rendering

### DIFF
--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -18,17 +18,6 @@ export function defineExternalParams() {
 	};
 }
 
-export var tileState;
-export function defineTileState() {
-	tileState = new function () {
-		this.seen = [];
-		this.corners = [[0, 0], [1, 1]];
-		this.normalized = [];
-		this.tiles = [];
-		this.view = [];
-	};
-}
-
 export var internalParams;
 export function defineInternalParams() {
 	internalParams = new function () {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -37,6 +37,7 @@ export function defineInternalParams() {
 		this.renderer = null;
 		this.scene = null;
 		this.group = null;
+		this.tileParent = null;
 
 		//for frustum      
 		this.zmax = 5.e10;
@@ -99,15 +100,16 @@ export function initScene() {
 	// scene
 	internalParams.scene = new THREE.Scene();
 
-
 	internalParams.group = new THREE.Group();
 	internalParams.scene.add(internalParams.group);
+
+	internalParams.tileParent = new THREE.Group();
+	internalParams.group.add(internalParams.tileParent);
 
 	const height = 1;
 	const width = height * aspect;
 	const near = 0;
 	const far = 1;
-
 
 	// Camera
 	var camera = new THREE.OrthographicCamera(

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -33,18 +33,13 @@ class TileConfig {
 		// but because these names make more sense. We might change the
 		// napari message to match.
 		this.levelIndex = config.level_index;;
-		this.numTileRows = config.shape_in_tiles[0];
 		this.tileSize = config.tile_size;
 
-		this.numTileRows = config.shape_in_tiles[0];
-		this.numTileCols = config.shape_in_tiles[1];
+		this.tileShape = config.shape_in_tiles;
+		this.levelShape = config.image_shape;
+		this.baseShape = config.base_shape;
 
-		this.numLevelRows = config.image_shape[0];
-		this.numLevelCols = config.image_shape[1];
-		this.maxLevelDim = Math.max(this.numLevelRows, this.numLevelCols);
-
-		this.numBaseRows = config.base_shape[0];
-		this.numBaseCols = config.base_shape[1];
+		this.maxLevelDim = Math.max(this.levelShape[0], this.levelShape[1]);
 	}
 }
 
@@ -244,8 +239,8 @@ function createTiles() {
 	// Start over with no tiles.
 	tileState.tiles = [];
 
-	const requestRows = tileConfig.numTileRows;
-	const requestCols = tileConfig.numTileCols;
+	const requestRows = tileConfig.tileShape[0];
+	const requestCols = tileConfig.tileShape[1];
 
 	console.log(`Request tiles ${requestRows} x ${requestCols}`);
 
@@ -255,8 +250,8 @@ function createTiles() {
 	// MAX_DIM totally messes things up, but it least it doesn't hang.
 	const MAX_TILE_DIM = 50;
 
-	const rows = Math.min(tileConfig.numTileRows, MAX_TILE_DIM);
-	const cols = Math.min(tileConfig.numTileCols, MAX_TILE_DIM);
+	const rows = Math.min(tileConfig.tileShape[0], MAX_TILE_DIM);
+	const cols = Math.min(tileConfig.tileShape[1], MAX_TILE_DIM);
 	const tileSize = tileConfig.tileSize;
 
 	// Use longer dimension so it fits in our [0..1] space. 
@@ -264,8 +259,8 @@ function createTiles() {
 
 	console.log(`Create tiles ${rows} x ${cols}`);
 
-	const levelRows = tileConfig.numLevelRows;
-	const levelCols = tileConfig.numLevelCols;
+	const levelRows = tileConfig.levelShape[0];
+	const levelCols = tileConfig.levelShape[1];
 
 	// Track tile's position in level pixels, so we know if we need a
 	// partial tile at the end of a row or column.
@@ -303,8 +298,8 @@ function createTiles() {
 // maybe it's a bit faster than create a new rect every frame?
 //
 function moveView() {
-	const baseX = tileConfig.numBaseCols;
-	const baseY = tileConfig.numBaseRows;
+	const baseX = tileConfig.baseShape[1];
+	const baseY = tileConfig.baseShape[0];
 
 	const bigger = Math.max(baseX, baseY)
 
@@ -333,8 +328,8 @@ function moveViewRect(pos, scale) {
 }
 
 function updateTileColors() {
-	var rows = tileConfig.numTileRows;
-	var cols = tileConfig.numTileCols;
+	var rows = tileConfig.tileShape[0];
+	var cols = tileConfig.tileShape[1];
 
 	var seenMap = new Map();
 

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -16,22 +16,16 @@ import {
 	initScene,
 } from './utils.js';
 
-// Draw the axes (red=X green=Y).
-const SHOW_AXES = true;
-
-// Draw the tiles themselves.
-const SHOW_TILES = true;
-
-// Draw the rect depicting Napari's current view frustum.
-const SHOW_VIEW = true;
+const SHOW_AXES = true;  // Draw the axes (red=X green=Y).
+const SHOW_TILES = true;  // Draw the tiles themselves.
+const SHOW_VIEW = true;  // Draw the yellow view frustum.
 
 class TileConfig {
 	constructor(config) {
 		this.config = config;  // The config from napari.
 
-		// Pull all these out not just to change the case of the variables,
-		// but because these names make more sense. We might change the
-		// napari message to match.
+		// Use better names. We should update napari to use these names
+		// (although keep the Python word_case).
 		this.levelIndex = config.level_index;;
 		this.tileSize = config.tile_size;
 

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -25,8 +25,6 @@ const SHOW_TILES = true;
 // Draw the rect depicting Napari's current view frustum.
 const SHOW_VIEW = true;
 
-// TODO: get rid of all these accessors once napari message is
-// improved to have better named keys.
 class TileConfig {
 	constructor(config) {
 		this.config = config;  // The config from napari.
@@ -132,8 +130,7 @@ const COLOR_TILE_ON = 0xE11313;  // red
 const COLOR_VIEW = 0xF5C542; // yellow
 
 // In a way the tiles are all full size with zero gaps between them,
-// but we draw the tiles a bit smaller so it looks like there is gap,
-// which just makes it easier to see them as individual tiles.
+// but we draw the tiles a bit smaller so it looks like there are gaps.
 const TILE_GAP = 0.05;
 
 function addToScene(object) {
@@ -144,6 +141,12 @@ function removeFromScene(object) {
 	internalParams.group.remove(object);
 }
 
+//
+// Draw a single thin line. 
+//
+// All lines are one pixel wide. There is a line width option but docs say
+// it does nothing in most renderers. And it seemed to do nothing for us.
+//
 function drawLine(start, end, color) {
 	const points = [];
 	points.push(new THREE.Vector2(...start));
@@ -157,6 +160,10 @@ function drawLine(start, end, color) {
 	addToScene(line);
 }
 
+//
+// Red line for X axis which is left to right.
+// Green line for Y axis which is top to bottom.
+//
 function createAxes() {
 	const depth = -1;
 	const origin = [0, 0, depth];
@@ -190,11 +197,6 @@ function createRect(rectColor, onTop = false) {
 		material.depthTest = false;
 		mesh.renderOrder = 10;
 	}
-
-	// Defaults to all zeros? Lets be explicit for now.
-	mesh.position.x = 0;
-	mesh.position.y = 0;
-	mesh.position.z = 0;
 
 	addToScene(mesh);
 	return mesh;

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -50,7 +50,7 @@ class Grid {
 
 	update() {
 		if (SHOW_TILES) {
-			updateTileColors();
+			updateSeen();
 		}
 
 		if (SHOW_VIEW) {
@@ -219,7 +219,7 @@ function createRect(rectColor, onTop = false) {
 //
 function createTile(pos, size) {
 
-	// Start as COLOR_TILE_OFF, later in updateTileColors() we toggle it
+	// Start as COLOR_TILE_OFF, later in updateSeen() we toggle it
 	// between COLOR_TILE_ON and COLOR_TILE_OFF depending on whether it was
 	// seen by the view.  
 	var mesh = createRect(COLOR_TILE_OFF);
@@ -349,7 +349,7 @@ function moveViewRect(pos, scale) {
 //
 // Update the color of all tiles. Red if seen, otherwise gray.
 //
-function updateTileColors() {
+function updateSeen() {
 	var rows = tileConfig.tileShape[0];
 	var cols = tileConfig.tileShape[1];
 

--- a/napari_client.py
+++ b/napari_client.py
@@ -208,7 +208,6 @@ class NapariClient(Thread):
         try:
             while True:
                 try:
-                    LOGGER.info("Getting remote messages")
                     message = self._remote.client_messages.get_nowait()
                 except ConnectionResetError:
                     LOGGER.error(


### PR DESCRIPTION
# Description
Improve viewer to handle large levels with sparse rendering.

Below level has 20,000 tiles which would be very slow to create up front. So we only create them as needed:

![napari-big-level](https://user-images.githubusercontent.com/4163446/100818620-83cc5d00-3418-11eb-8adb-c4b3806b7bd2.gif)
