### PR TITLE
Use HTML form instead of three.js UI

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -82,6 +82,10 @@ class NapariBridge:
                 self.client.send_command(command)
 
     def _process_messages(self) -> None:
+        """Process message from napari."""
+        if self.client is None:
+            return
+
         while True:
             message = self.client.get_napari_message()
 

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -11,13 +11,6 @@ import io from 'socket.io-client';
 
 const ZOOM = 0.8;
 
-export var externalParams;
-export function defineExternalParams() {
-	externalParams = new function () {
-		this.show_grid = false;
-	};
-}
-
 export var internalParams;
 export function defineInternalParams() {
 	internalParams = new function () {
@@ -60,14 +53,6 @@ export function getURLvars() {
 		vars[key] = value;
 	});
 	return vars;
-}
-
-export function setParamsFromURL() {
-	var vars = getURLvars();
-	var keys = Object.keys(vars);
-	keys.forEach(function (k) {
-		externalParams[k] = parseFloat(vars[k])
-	});
 }
 
 //
@@ -127,15 +112,4 @@ export function initScene() {
 
 	//controls
 	internalParams.controls = new TrackballControls(internalParams.camera, internalParams.renderer.domElement);
-}
-
-export function setURLvars() {
-	var keys = Object.keys(externalParams);
-	var vars = "/gui?" //this needs to be the same as what is in flask
-	keys.forEach(function (k) {
-		if (k != "gui") {
-			vars += k + "=" + externalParams[k] + "&";
-		}
-	});
-	window.history.pushState("externalParams", "updated", vars);
 }

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -4,7 +4,6 @@
 // WebGL display of which octree tiles are visible in napari.
 //
 import * as THREE from 'three';
-import { GUI } from 'dat.gui';
 
 import {
 	externalParams,
@@ -71,7 +70,7 @@ class TileState {
 		const max = Number.MAX_SAFE_INTEGER;
 		var corner = [max, max];
 
-		console.log("seen = ", this.message.seen);
+		// console.log("seen = ", this.message.seen);
 
 		this.message.seen.forEach(function (coord) {
 			// Map keys can't really be arrays, so use a string.
@@ -85,7 +84,7 @@ class TileState {
 		});
 
 		this.seenMap = seenMap;
-		console.log("seenMap = ", seenMap.size);
+		// console.log("seenMap = ", seenMap.size);
 
 		// Choose corner which is up to MAX_TILE_SPAN/2 less than the real 
 		// corner. So if we draw the grid from that corner, we can see
@@ -456,7 +455,7 @@ function createViewer() {
 
 
 	if (SHOW_VIEW) {
-		console.log("createView");
+		console.log("createViewer");
 		grid.view = createRect(COLOR_VIEW, true);
 		addToScene(grid.view);
 		//internalParams.tileParent.add(grid.view);
@@ -479,14 +478,6 @@ function createViewer() {
 }
 
 //
-// Create the GUI.
-//
-function createGUI() {
-	internalParams.gui = new GUI();
-	internalParams.gui.add(externalParams, 'show_grid').onChange(sendGUIinfo);
-}
-
-//
 // Send the GUI settings back to Flask.
 //
 function sendGUIinfo() {
@@ -503,6 +494,19 @@ function animateViewer(time) {
 	internalParams.renderer.render(internalParams.scene, internalParams.camera);
 }
 
+function setupControls() {
+	const showGrid = document.getElementById('showGrid');
+	showGrid.addEventListener('change', event => {
+		externalParams.show_grid = event.target.checked;
+		sendGUIinfo();
+	});
+
+	const selectCar = document.getElementById('selectCar');
+	selectCar.onchange = function () {
+		alert(selectCar.value);
+	}
+}
+
 //
 // Called on startup.
 //
@@ -513,7 +517,7 @@ export function startViewer() {
 	defineExternalParams();
 
 	initScene();
-	createGUI();
+	setupControls();
 
 	createViewer();
 	animateViewer();

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -6,8 +6,6 @@
 import * as THREE from 'three';
 
 import {
-	externalParams,
-	defineExternalParams,
 	internalParams,
 	defineInternalParams,
 	initScene,
@@ -19,6 +17,19 @@ const SHOW_VIEW = true;  // Draw the yellow view frustum.
 
 // MAX_TILE_SPAN is the most tiles we'll show across.
 const MAX_TILE_SPAN = 4;
+
+class ViewerControls {
+	constructor() {
+		this.show_grid = false;
+	}
+
+	send() {
+		console.log('send()', this);
+		internalParams.socket.emit('send_command', this);
+	}
+}
+
+var viewerControls = new ViewerControls();
 
 //
 // The (rows x cols) in the current level and related information.
@@ -478,14 +489,6 @@ function createViewer() {
 }
 
 //
-// Send the GUI settings back to Flask.
-//
-function sendGUIinfo() {
-	console.log("send command", externalParams);
-	internalParams.socket.emit('send_command', externalParams);
-}
-
-//
 // Animation loop. Not using this yet?
 //
 function animateViewer(time) {
@@ -497,8 +500,8 @@ function animateViewer(time) {
 function setupControls() {
 	const showGrid = document.getElementById('showGrid');
 	showGrid.addEventListener('change', event => {
-		externalParams.show_grid = event.target.checked;
-		sendGUIinfo();
+		viewerControls.show_grid = event.target.checked;
+		viewerControls.send();
 	});
 
 	const selectCar = document.getElementById('selectCar');
@@ -514,7 +517,6 @@ export function startViewer() {
 	console.log("startViewer")
 
 	defineInternalParams();
-	defineExternalParams();
 
 	initScene();
 	setupControls();

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -17,6 +17,17 @@
 <main>
 	<div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
 		<!-- Viewer Content -->
+		<div class="p-8">
+			<input type="checkbox" id="showGrid" checked>
+			<label for="ShowGrid">Show Grid</label><br>
+			<label for="selectCar">Choose a car:</label>
+			<select id="selectCar" name="carlist" form="carform">
+				<option value="volvo">Volvo</option>
+				<option value="saab">Saab</option>
+				<option value="opel">Opel</option>
+				<option value="audi">Audi</option>
+			</select>
+		</div>
 		<div id="WebGLContainer" class="webgl"></div>
 	</div>
 </main>

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -20,12 +20,11 @@
 		<div class="p-8">
 			<input type="checkbox" id="showGrid" checked>
 			<label for="ShowGrid">Show Grid</label><br>
-			<label for="selectCar">Choose a car:</label>
-			<select id="selectCar" name="carlist" form="carform">
-				<option value="volvo">Volvo</option>
-				<option value="saab">Saab</option>
-				<option value="opel">Opel</option>
-				<option value="audi">Audi</option>
+			<label for="selectLoad">TiledImageVisual Load:</label>
+			<select id="selectLoad" form="tiledImageVisual">
+				<option value="manual">Manual</option>
+				<option value="one">One</option>
+				<option value="all">All</option>
 			</select>
 		</div>
 		<div id="WebGLContainer" class="webgl"></div>


### PR DESCRIPTION
# Description

* Use an HTML form for our **Show Grid** checkbox.
* Retire the three.js "gui" which was pretty awkward looking.
* Plan is to use mostly HTML UI going forward.

# Demo

Far left I'm togging the new HTML "Show Grid" checkbox:

Then from left to right we have three consoles/logs:

1. Left is the Javascript app that's sending the value to **webmon** via sockets.
2. Center is the Python **webmon** process that got the value from Javascript via sockets.
3. Right is the Python **napari** process that go the value from **webmon** via shared memory.

![webmon-toggle-grid](https://user-images.githubusercontent.com/4163446/101266433-e1b0bb80-371c-11eb-88d4-51eeb1bebac3.gif)
